### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ distributions.</p>
 
 ## Install
 
-    sudo snap install waterfox-snap
+    sudo snap install --edge --devmode waterfox-snap
 
 <!-- Uncomment and modify this when your snap is available on the store
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-white.svg)](https://snapcraft.io/waterfox-snap)


### PR DESCRIPTION
![image](https://framapic.org/mSW96nN9U8Ls/uW9HxM8zqrgT.png)
If the snap isn’t entirely ready, if would surely be useful to currently, use the correct command to install it in this state.
Once it will be ready for the Snap Store, then we could restore the original command.